### PR TITLE
refactor: separate the sidebar groups into multiple components

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,11 +1,14 @@
 "use client"
 
-import {
-  JoystickIcon
-} from "lucide-react"
-import type React from "react"
+import { JoystickIcon } from "lucide-react";
+import Link from 'next/link';
+import type React from "react";
 
-import { NavMain } from "@/components/nav-main"
+import { NavEntity } from "@/components/nav-entity";
+import { NavEssential } from "@/components/nav-essential";
+import { NavMain } from "@/components/nav-main";
+import { NavObjects } from "@/components/nav-objects";
+import { NavWalls } from "@/components/nav-walls";
 import {
   Sidebar,
   SidebarContent,
@@ -13,8 +16,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem
-} from "@/components/ui/sidebar"
-import Link from 'next/link'
+} from "@/components/ui/sidebar";
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
@@ -33,6 +35,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <NavMain />
+        <NavEssential />
+        <NavEntity />
+        <NavObjects />
+        <NavWalls />
       </SidebarContent>
     </Sidebar>
   )

--- a/src/components/nav-entity.tsx
+++ b/src/components/nav-entity.tsx
@@ -1,0 +1,35 @@
+import { RequiredBadge } from "@/components/required-badge";
+import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import { ArrowUpRightIcon, PersonStandingIcon, SwordIcon } from "lucide-react";
+
+export function NavEntity() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Entity</SidebarGroupLabel>
+
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Player">
+            <PersonStandingIcon />
+            <span>Player</span>
+          </SidebarMenuButton>
+          <RequiredBadge />
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Gladiator">
+            <SwordIcon />
+            <span>Gladiator</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Archer">
+            <ArrowUpRightIcon />
+            <span>Archer</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  );
+}

--- a/src/components/nav-essential.tsx
+++ b/src/components/nav-essential.tsx
@@ -1,0 +1,36 @@
+import { RequiredBadge } from "@/components/required-badge";
+import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import { DiamondIcon, FlagIcon, SkullIcon } from "lucide-react";
+
+export function NavEssential() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Essential</SidebarGroupLabel>
+
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Spawn player">
+            <DiamondIcon />
+            <span>Spawn player</span>
+          </SidebarMenuButton>
+          <RequiredBadge />
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="End">
+            <FlagIcon />
+            <span>End</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Death">
+            <SkullIcon />
+            <span>Death</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,38 +1,50 @@
 "use client";
 
+import { BoxesIcon, HouseIcon, SettingsIcon } from "lucide-react";
+import { useState } from "react";
+
+import { SettingsDialog } from "@/components/settings-dialog";
 import {
   SidebarGroup,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem
 } from "@/components/ui/sidebar";
-import { BoxesIcon, CogIcon, HouseIcon } from "lucide-react";
 
 export function NavMain() {
+  const [settingsOpen, setSettingsOpen] = useState(false)
+
   return (
-    <SidebarGroup>
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton tooltip="Home">
-            <HouseIcon />
-            <span>Home</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
+    <>
+      <SidebarGroup>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton tooltip="Home">
+              <HouseIcon />
+              <span>Home</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
 
-        <SidebarMenuItem>
-          <SidebarMenuButton tooltip="Settings">
-            <CogIcon />
-            <span>Settings</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              tooltip="Settings"
+              onClick={() => setSettingsOpen(true)}
+            >
+              <SettingsIcon />
+              <span>Settings</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
 
-        <SidebarMenuItem>
-          <SidebarMenuButton tooltip="Assets">
-            <BoxesIcon />
-            <span>Assets</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      </SidebarMenu>
-    </SidebarGroup>
+          <SidebarMenuItem>
+            <SidebarMenuButton tooltip="Assets">
+              <BoxesIcon />
+              <span>Assets</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+
+      <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+    </>
   )
 }

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -2,159 +2,37 @@
 
 import {
   SidebarGroup,
-  SidebarGroupLabel,
   SidebarMenu,
-  SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem
 } from "@/components/ui/sidebar";
-import { ArrowUpRightIcon, AsteriskIcon, BoxesIcon, CogIcon, CoinsIcon, DiamondIcon, FlagIcon, HeartPulseIcon, HouseIcon, LucideIcon, PersonStandingIcon, SkullIcon, SquareIcon, SwordIcon } from "lucide-react";
-import { usePathname } from "next/navigation";
-
-interface Group {
-  label?: string
-  items: GroupItem[]
-}
-
-interface GroupItem {
-  title: string
-  value: string
-  icon: LucideIcon,
-  required?: boolean
-}
-
-const groups: Group[] = [
-  {
-    items: [
-      {
-        title: "Home",
-        value: "home",
-        icon: HouseIcon,
-      },
-      {
-        title: "Settings",
-        value: "config",
-        icon: CogIcon,
-      },
-      {
-        title: "Assets",
-        value: "assets",
-        icon: BoxesIcon,
-      },
-    ]
-  },
-  {
-    label: "Essential",
-    items: [
-      {
-        title: "Spawn Player",
-        value: "",
-        icon: DiamondIcon,
-        required: true,
-      },
-      {
-        title: "End",
-        value: "end",
-        icon: FlagIcon,
-      },
-      {
-        title: "Death",
-        value: "death",
-        icon: SkullIcon,
-      },
-    ]
-  },
-  {
-    label: "Entity",
-    items: [
-      {
-        title: "Player",
-        value: "player",
-        icon: PersonStandingIcon,
-        required: true,
-      },
-      {
-        title: "Gladiator",
-        value: "gladiator",
-        icon: SwordIcon,
-      },
-      {
-        title: "Archer",
-        value: "archer",
-        icon: ArrowUpRightIcon,
-      },
-    ]
-  },
-  {
-    label: "Objects",
-    items: [
-      {
-        title: "Life",
-        value: "life",
-        icon: HeartPulseIcon,
-      },
-      {
-        title: "Arrow",
-        value: "arrow",
-        icon: ArrowUpRightIcon,
-      },
-      {
-        title: "CoinsIcon",
-        value: "coins",
-        icon: CoinsIcon,
-      },
-    ]
-  },
-  {
-    label: "Walls",
-    items: [
-      {
-        title: "Black",
-        value: "black",
-        icon: SquareIcon,
-      },
-      {
-        title: "Red",
-        value: "red",
-        icon: SquareIcon,
-      },
-      {
-        title: "Green",
-        value: "green",
-        icon: SquareIcon,
-      },
-    ]
-  }
-];
+import { BoxesIcon, CogIcon, HouseIcon } from "lucide-react";
 
 export function NavMain() {
-  const pathname = usePathname();
-
   return (
-    <>
-      {groups.map((group, idx) => (
-        <SidebarGroup key={idx}>
-          {group.label && <SidebarGroupLabel>{group.label}</SidebarGroupLabel>}
-          <SidebarMenu>
-            {group.items.map((item) => (
-              <SidebarMenuItem key={item.title}>
-                <SidebarMenuButton
-                  tooltip={item.title}
-                  className="transition-[font-weight]"
-                >
-                  {item.icon && <item.icon />}
-                  <span>{item.title}</span>
-                </SidebarMenuButton>
-                {item.required && (
-                  <SidebarMenuBadge>
-                    <AsteriskIcon className="size-4 text-amber-500 dark:text-amber-400" />
-                  </SidebarMenuBadge>
-                )}
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
-      ))}
-    </>
-  );
+    <SidebarGroup>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Home">
+            <HouseIcon />
+            <span>Home</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Settings">
+            <CogIcon />
+            <span>Settings</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Assets">
+            <BoxesIcon />
+            <span>Assets</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
 }

--- a/src/components/nav-objects.tsx
+++ b/src/components/nav-objects.tsx
@@ -1,0 +1,34 @@
+import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import { ArrowUpRightIcon, CoinsIcon, HeartPulseIcon } from "lucide-react";
+
+export function NavObjects() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Essential</SidebarGroupLabel>
+
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Life">
+            <HeartPulseIcon />
+            <span>Life</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Arrow">
+            <ArrowUpRightIcon />
+            <span>Arrow</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Coins">
+            <CoinsIcon />
+            <span>Coins</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+

--- a/src/components/nav-walls.tsx
+++ b/src/components/nav-walls.tsx
@@ -1,0 +1,34 @@
+import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
+import { BrickWallIcon } from "lucide-react";
+
+export function NavWalls() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Walls</SidebarGroupLabel>
+
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Black">
+            <BrickWallIcon />
+            <span>Black</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Red">
+            <BrickWallIcon className="text-red-600 dark:text-red-400" />
+            <span>Red</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Green">
+            <BrickWallIcon className="text-emerald-600 dark:text-emerald-400" />
+            <span>Green</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+

--- a/src/components/required-badge.tsx
+++ b/src/components/required-badge.tsx
@@ -1,0 +1,10 @@
+import { SidebarMenuBadge } from "@/components/ui/sidebar";
+import { AsteriskIcon } from "lucide-react";
+
+export function RequiredBadge() {
+  return (
+    <SidebarMenuBadge>
+      <AsteriskIcon className="size-4 text-amber-500 dark:text-amber-400" />
+    </SidebarMenuBadge>
+  )
+}

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,0 +1,34 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export function SettingsDialog({ ...props }: React.ComponentProps<typeof Dialog>) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription>
+            Change the game settings here.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 gap-6 min-h-96">
+          <div>First column</div>
+          <div>Second column</div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">
+              Cancel
+            </Button>
+          </DialogClose>
+
+          <Button>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
As discussed with @GardenMovie today, this will allow a better control on events when we need to introduce the dialogs, which will need a lot of `onClick` handlers and states.