### PR TITLE
ci: remove hardcoded stuff for cache and the deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,17 +36,6 @@ jobs:
         with:
           static_site_generator: next
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            .next/cache
-          
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,17 +23,6 @@ jobs:
           node-version: 23.x
           cache: 'pnpm'
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            .next/cache
-          
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Install dependencies
         run: pnpm install
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  basePath: "/raycasting-engine",
   output: "export",
 };
 


### PR DESCRIPTION
Let the actions handle it as they should do.

Cache is already handled by the setup-node action, and the Next config is injected automatically by the configure-pages action.

This fixes the 404 error on development, no need anymore to access it with `/raycasting-engine`.